### PR TITLE
fix(deps): resolve 4 Dependabot alerts for postcss

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "@vercel/fun/tar": "^7.5.11",
     "@vercel/node/undici": "^5.29.0",
     "@vercel/python-analysis/minimatch": "^10.2.3",
-    "micromatch/picomatch": "^2.3.2"
+    "micromatch/picomatch": "^2.3.2",
+    "vite/postcss": ">=8.5.23 <9"
   },
   "dependencies": {
     "@ariakit/react": "0.4.37",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6167,7 +6167,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11, nanoid@npm:^3.3.16, nanoid@npm:^3.3.17":
+"nanoid@npm:^3.3.16, nanoid@npm:^3.3.17":
   version: 3.3.18
   resolution: "nanoid@npm:3.3.18"
   bin:
@@ -6845,7 +6845,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.25":
+"postcss@npm:>=8.5.23 <9":
   version: 8.5.26
   resolution: "postcss@npm:8.5.26"
   dependencies:
@@ -6853,17 +6853,6 @@ __metadata:
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
   checksum: 10c0/2bdafc00d96bd57b6649a52e458864a4bf58ee56cfdbe4aea1472b5cccc127e6c1ad653bd0bec50d211e650eb0b9270c80e1e72aff2e2fa40d9e7363234d6e43
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.8":
-  version: 8.5.9
-  resolution: "postcss@npm:8.5.9"
-  dependencies:
-    nanoid: "npm:^3.3.11"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/7cb2b32202ea1ead03f15cfbb2756a64a0f98942378e99b3dfce33678fe5eaf93e31d675a46e3a0dfb417d7b49b82d8999d0dd42a33c3b128e71ade0f978719a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Resolves 4 Dependabot alert(s) for `postcss` by adding a scoped override targeting the `vite` parent
- Target version: >=8.5.23 <9
- Resolved version: 8.5.23, 8.5.26 (both resolved copies now clear every alert's vulnerable range)

Of the three resolved copies at baseline (8.5.9, 8.5.23, 8.5.26), only the `vite@8.0.8 -> postcss@8.5.9` copy was vulnerable to all four alerts. The `next` (8.5.23) and one `vite@8.2.1` (8.5.26) copies were already patched against every alert and were not bumped further than necessary; the override is scoped to the `vite` parent only, not a bare/global override.

## Alerts resolved

| # | CVE | Severity | EPSS | Summary |
|---|---|---|---|---|
| [#165](https://github.com/brianespinosa/resume/security/dependabot/165) | CVE-2026-69153 | medium | 23.7% | Incomplete fix of GHSA-6g55-p6wh-862q -- attacker-controlled sourceMappingURL reads arbitrary .map files when `from` is unset |
| [#157](https://github.com/brianespinosa/resume/security/dependabot/157) | CVE-2026-73646 | high | 0% | Path Traversal in Previous Source Map Auto-Loading (sourceMappingURL) leads to Arbitrary .map File Disclosure |
| [#156](https://github.com/brianespinosa/resume/security/dependabot/156) | CVE-2026-45623 | high | 45.8% | Arbitrary file read and information disclosure via attacker-controlled sourceMappingURL in CSS comments |
| [#123](https://github.com/brianespinosa/resume/security/dependabot/123) | CVE-2026-41305 | medium | 10.5% | XSS via Unescaped `</style>` in CSS Stringify Output |

## Merge risk: Medium (6/10)

| Factor | Score | Evidence |
|---|---|---|
| Version delta | 0 | 8.5.9 -> 8.5.23 (patch) |
| Runtime exposure | 1 | transitive under a runtime dependency |
| Usage surface | 2 | imported in 6 module(s) for parents of postcss |
| Test signal | 1 | tests pass; affected modules not clearly exercised |
| Verification | 2 | one or more scripts skipped or partially run |

EPSS percentile (above) reflects how urgent the underlying vulnerabilities are; merge risk (above) is a separate signal reflecting how risky this specific fix is to merge into this repo.

## Dependency chain

```
├─ next@npm:16.3.0
│  └─ postcss@npm:8.5.23 (via npm:8.5.23)
│
├─ next@npm:16.3.0 [d3ee5]
│  └─ postcss@npm:8.5.23 (via npm:8.5.23)
│
├─ vite@npm:8.0.8
│  └─ postcss@npm:8.5.9 (via npm:^8.5.8)
│
├─ vite@npm:8.2.1
│  └─ postcss@npm:8.5.26 (via npm:^8.5.25)
│
└─ vite@npm:8.2.1 [d3ee5]
   └─ postcss@npm:8.5.26 (via npm:^8.5.25)
```

## Changes

```json
"resolutions": {
  "vite/postcss": ">=8.5.23 <9"
}
```

## Verification

- [x] Lockfile validated: 2 resolved version(s) (8.5.23, 8.5.26) satisfy `>=8.5.23 <9`; the previously-vulnerable 8.5.9 copy is gone
- [x] `yarn typecheck` passes
- [x] `yarn test` passes (2 tests, 1 file -- does not exercise postcss/CSS pipeline directly)
- [x] `yarn build` passes (Next.js production build, CSS/PostCSS pipeline exercised end-to-end)
- [x] `yarn knip` passes (pre-existing, unrelated config hint about `sort-package-json` in `knip.config.ts`)
- [x] `biome check .` passes (ran without `--write` in place of `yarn check`, which mutates; pre-existing info-level notices about `biome.json` schema version, unrelated to this change)
- [ ] `yarn e2e` skipped -- requires a running preview server not available in this environment; CI is the verifier

## References

- https://github.com/brianespinosa/resume/security/dependabot/165
- https://github.com/brianespinosa/resume/security/dependabot/157
- https://github.com/brianespinosa/resume/security/dependabot/156
- https://github.com/brianespinosa/resume/security/dependabot/123