### PR TITLE
fix(deps): resolve 3 Dependabot alerts for js-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@vercel/fun/@tootallnate/once": "^3.0.1",
     "@vercel/fun/tar": "^7.5.11",
     "@vercel/node/undici": "^5.29.0",
+    "@vercel/python-analysis/js-yaml": ">=4.3.1 <5",
     "@vercel/python-analysis/minimatch": "^10.2.3",
     "micromatch/picomatch": "^2.3.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5066,14 +5066,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:4.1.1":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
+"js-yaml@npm:>=4.3.1 <5":
+  version: 4.3.1
+  resolution: "js-yaml@npm:4.3.1"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
+  checksum: 10c0/13c500ca322e0c3f8c81686e6ecda96d2ea37b45247a420c17c7db36932d6965cc27391abc2d1a104501600e7f0d947a5f8b7be6db619c4fefa87901b3512807
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Resolves 3 Dependabot alerts for `js-yaml` by adding a scoped override
- Target version: >=4.3.1
- Resolved version: 4.3.1

## Alerts resolved

| # | CVE | Severity | EPSS | Summary |
|---|---|---|---|---|
| [#174](https://github.com/brianespinosa/resume/security/dependabot/174) | GHSA-5p4m-2wfm-xmqj | high | 0% | Quadratic CPU consumption in `!!omap` resolution (3.x and 4.x); CVE-2026-59870 fix not backported |
| [#148](https://github.com/brianespinosa/resume/security/dependabot/148) | CVE-2026-59869 | high | 34.7% | YAML merge-key chains can force quadratic CPU consumption |
| [#146](https://github.com/brianespinosa/resume/security/dependabot/146) | CVE-2026-53550 | medium | 30.5% | Quadratic-complexity DoS in merge key handling via repeated aliases |

## Merge risk: Medium (5/10)

| Factor | Score | Evidence |
|---|---|---|
| Version delta | 1 | 4.1.1 -> 4.3.1 (minor) |
| Runtime exposure | 1 | transitive under a runtime dependency |
| Usage surface | 0 | no source imports found for parents of js-yaml (build or tooling only) |
| Test signal | 1 | tests pass; affected modules not clearly exercised |
| Verification | 2 | one or more scripts skipped or partially run |

## Dependency chain

```
└─ @vercel/python-analysis@npm:0.13.1
   └─ js-yaml@npm:4.3.1 (via npm:>=4.3.1 <5)
```

`js-yaml` is a single-copy transitive dependency of `@vercel/python-analysis`, itself a Vercel tooling package (not exercised by application source, per the F3 usage-surface check).

## Changes

```json
"resolutions": {
  "@vercel/python-analysis/js-yaml": ">=4.3.1 <5"
}
```

Scoped to the sole parent (`@vercel/python-analysis`), bounded to the major-4 line (`>=4.3.1 <5`) so future major bumps are not auto-installed. `4.3.1` is the smallest version that clears all three alerts' vulnerable ranges (alert #174 requires `< 4.3.1`, which is the binding constraint).

## Verification

- [x] Lockfile validated: 1 resolved version (`4.3.1`) satisfies `>=4.3.1 <5`, and is the only resolved copy of `js-yaml` in the lockfile (870 entries scanned) — no copies remain in any alert's vulnerable range
- [x] `yarn typecheck` passes
- [x] `yarn test` passes (2 tests; do not exercise `@vercel/python-analysis`/`js-yaml`, which is Vercel build tooling, not application code)
- [x] `yarn build` passes (Next.js production build succeeds)
- [x] `yarn knip` passes (pre-existing config hint about `sort-package-json` in `ignoreBinaries`, unrelated to this change)
- [x] `biome check .` passes (2 pre-existing info-level notices about `biome.json` schema version mismatch, unrelated to this change; ran without `--write` to avoid unrelated formatting churn)
- [ ] `yarn e2e` skipped: requires a running app server at `http://localhost:3000` (no `webServer` block in `playwright.config.ts` to auto-start one, and starting a long-lived dev server is out of scope for local verification); CI is the verifier for this check
- No new `yarn install` warnings introduced by this change

## References

- https://github.com/brianespinosa/resume/security/dependabot/174
- https://github.com/brianespinosa/resume/security/dependabot/148
- https://github.com/brianespinosa/resume/security/dependabot/146