### PR TITLE
fix(deps): resolve 11 of 19 Dependabot alerts for undici

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,12 @@
   },
   "resolutions": {
     "@vercel/backends/srvx": "^0.11.13",
+    "@vercel/blob/undici": ">=6.28.0 <7",
     "@vercel/fun/@tootallnate/once": "^3.0.1",
     "@vercel/fun/tar": "^7.5.11",
     "@vercel/node/undici": "^5.29.0",
     "@vercel/python-analysis/minimatch": "^10.2.3",
+    "@vercel/sandbox/undici": ">=7.29.0 <8",
     "micromatch/picomatch": "^2.3.2"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8058,17 +8058,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^6.23.0":
-  version: 6.24.1
-  resolution: "undici@npm:6.24.1"
-  checksum: 10c0/53fdbaa357139a2c12deed34f67d67fc6ad269630ba85a1507e7717f53ad2d3a02c95fbd17d3ab321e34c60b6f0a716cdc2f7e2eca1e07178702dc89cc3a73c4
+"undici@npm:>=6.28.0 <7":
+  version: 6.28.0
+  resolution: "undici@npm:6.28.0"
+  checksum: 10c0/3029a70df06b38b5b2f30732932a1e92544c753cd82c8abdf0d35afad48e0ba91612e79fe3a442dbbb9434d6a9eba2b714d5ea28984c903dda2b5d5444f38354
   languageName: node
   linkType: hard
 
-"undici@npm:^7.27.1":
-  version: 7.27.2
-  resolution: "undici@npm:7.27.2"
-  checksum: 10c0/714632147c80eb8eda8a52df51b481d346df5e035ccc1d87eb3bbcb8f92ec25d7cbbe81abdeae5db4e37a93e490c8d2fa2359ecdca4b2c5c6c513dcd2626ad47
+"undici@npm:>=7.29.0 <8":
+  version: 7.29.0
+  resolution: "undici@npm:7.29.0"
+  checksum: 10c0/85ea96e91e7f3de24de678cbbc54230fdd641a3b0643005f2aef044af1f1a2db8fbecb88b28e6fa78bb41ffeafda4479b57075b6b6ab92beac4b7b5ab53f9b10
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Resolves **11 of 19** Dependabot alerts for `undici` via scoped `resolutions` overrides on two of its four parents
- `undici` resolves at **three concurrent copies** in this lockfile (5.29.0, 6.24.1, 7.27.2) because three different `vercel`-family packages each pin their own major line. Neither `highest_fixed_version` (7.29.0) nor a single derived range covers all three; each copy needed its own per-parent, major-bounded constraint.
- **8 alerts remain open** — see "Unresolved copy" below.

## Alerts resolved

| # | CVE | Severity | EPSS | Summary |
|---|---|---|---|---|
| [#173](https://github.com/brianespinosa/resume/security/dependabot/173) | CVE-2026-15157 | medium | 5.0% | CRLF Injection via blob-like body 'type' property |
| [#171](https://github.com/brianespinosa/resume/security/dependabot/171) | CVE-2026-14643 | medium | 13.9% | Cross-user info disclosure via whitespace in Cache-Control directives |
| [#170](https://github.com/brianespinosa/resume/security/dependabot/170) | CVE-2026-16729 | medium | 6.3% | Cookie attribute injection via unsanitized domain/setCookie fields |
| [#168](https://github.com/brianespinosa/resume/security/dependabot/168) | CVE-2026-16728 | medium | 7.3% | Downstream response desync via retry interceptor |
| [#166](https://github.com/brianespinosa/resume/security/dependabot/166) | CVE-2026-13697 | **high** | 25.0% | Cross-user info disclosure and parse-time crash via degenerate private cache directives |
| [#145](https://github.com/brianespinosa/resume/security/dependabot/145) | CVE-2026-11525 | low | 15.0% | Set-Cookie SameSite downgrade via permissive substring matching |
| [#143](https://github.com/brianespinosa/resume/security/dependabot/143) | CVE-2026-9679 | medium | 17.6% | HTTP header injection via Set-Cookie percent-decoding |
| [#139](https://github.com/brianespinosa/resume/security/dependabot/139) | CVE-2026-6734 | **high** | 27.6% | Cross-origin request routing via SOCKS5 proxy pool reuse |
| [#138](https://github.com/brianespinosa/resume/security/dependabot/138) | CVE-2026-6733 | low | 12.6% | HTTP response queue poisoning via keep-alive socket reuse |
| [#136](https://github.com/brianespinosa/resume/security/dependabot/136) | CVE-2026-9697 | **high** | 37.5% | TLS certificate validation bypass via dropped requestTls in SOCKS5 ProxyAgent |
| [#135](https://github.com/brianespinosa/resume/security/dependabot/135) | CVE-2026-9678 | medium | 28.5% | Cross-user info disclosure via shared cache whitespace bypass |

## Unresolved copy — undici@5.29.0 (8 alerts remain open)

`undici@5.29.0` is pulled in twice with no in-major fix available:

- **`@vercel/node@5.9.8`** declares `undici@^5.29.0`. This repo already has a pre-existing scoped resolution, `@vercel/node/undici: ^5.29.0`, pinning it to that exact vulnerable range.
- **`vercel@58.9.1`** (two instances in the tree) pins `undici@5.29.0` exactly (no caret).

Every fix for the affected CVEs below lives in the 6.x or 7.x line (`fixed_in` is 6.24.0/6.27.0/6.28.0); there is no patched 5.x release. Forcing either parent onto 6.x/7.x would cross a major version boundary undici did not backport into 5.x, on a `devDependency` (the `vercel` CLI) whose undici usage is internal build/deploy tooling, not exercised by this repo's own test, build, or typecheck scripts. I could not verify such a jump would leave the CLI functional, so I did not apply it here rather than land an unverified change.

**Alerts still open** (all match `undici < 6.24.0/6.27.0/6.28.0` with no lower version bound, so they still match the 5.29.0 copy):

| # | CVE | Severity | EPSS | Summary |
|---|---|---|---|---|
| [#172](https://github.com/brianespinosa/resume/security/dependabot/172) | CVE-2026-15157 | medium | 5.0% | CRLF Injection via blob-like body 'type' property |
| [#169](https://github.com/brianespinosa/resume/security/dependabot/169) | CVE-2026-16729 | medium | 6.3% | Cookie attribute injection via unsanitized domain/setCookie fields |
| [#167](https://github.com/brianespinosa/resume/security/dependabot/167) | CVE-2026-16728 | medium | 7.3% | Downstream response desync via retry interceptor |
| [#144](https://github.com/brianespinosa/resume/security/dependabot/144) | CVE-2026-11525 | low | 15.0% | Set-Cookie SameSite downgrade via permissive substring matching |
| [#142](https://github.com/brianespinosa/resume/security/dependabot/142) | CVE-2026-9679 | medium | 17.6% | HTTP header injection via Set-Cookie percent-decoding |
| [#137](https://github.com/brianespinosa/resume/security/dependabot/137) | CVE-2026-6733 | low | 12.6% | HTTP response queue poisoning via keep-alive socket reuse |
| [#115](https://github.com/brianespinosa/resume/security/dependabot/115) | CVE-2026-1527 | medium | 16.7% | CRLF Injection via `upgrade` option |
| [#114](https://github.com/brianespinosa/resume/security/dependabot/114) | CVE-2026-1525 | medium | 39.5% | HTTP Request/Response Smuggling |

**Recommended follow-up** (needs a human decision, not made here): either confirm `vercel`/`@vercel/node` tolerate undici 6.x/7.x in a manual smoke test and force the override, or track upstream `vercel`/`@vercel/node` releases that bump their own undici dependency past 5.x.

## Merge risk

Scored against the largest change made (`@vercel/sandbox`'s copy, 7.27.2 -> 7.29.0). This does **not** reflect the unresolved 5.29.0 copy above, which carries its own unmitigated risk (8 open alerts, one rated high severity).

## Merge risk: Medium (5/10)

| Factor | Score | Evidence |
|---|---|---|
| Version delta | 1 | 7.27.2 -> 7.29.0 (minor) |
| Runtime exposure | 1 | transitive under a runtime dependency |
| Usage surface | 0 | no source imports found for parents of undici (build or tooling only) |
| Test signal | 1 | tests pass; affected modules not clearly exercised |
| Verification | 2 | one or more scripts skipped or partially run |

## Dependency chain

```
├─ @vercel/blob@npm:2.4.0
│  └─ undici@npm:6.28.0 (via npm:>=6.28.0 <7)
│
├─ @vercel/node@npm:5.9.8
│  └─ undici@npm:5.29.0 (via npm:^5.29.0)
│
├─ @vercel/sandbox@npm:2.4.0
│  └─ undici@npm:7.29.0 (via npm:>=7.29.0 <8)
│
├─ vercel@npm:58.9.1
│  └─ undici@npm:5.29.0 (via npm:5.29.0)
│
└─ vercel@npm:58.9.1 [d3ee5]
   └─ undici@npm:5.29.0 (via npm:5.29.0)
```

## Changes

```json
"resolutions": {
    ...
    "@vercel/blob/undici": ">=6.28.0 <7",
    "@vercel/sandbox/undici": ">=7.29.0 <8"
}
```

No bare/global override was added or modified — both new entries are scoped to a single parent, matching the existing pattern already used in this manifest (e.g. `@vercel/node/undici`, `@vercel/python-analysis/minimatch`). The pre-existing `@vercel/node/undici: ^5.29.0` entry was left untouched (see "Unresolved copy" above for why).

## Verification

- [x] Lockfile validated (manually, not via the adapter's single-range `validate`, which cannot express three concurrent major lines — see below): `undici@6.28.0` clears every alert with `vulnerable_range` in the 6.x line; `undici@7.29.0` clears every alert with `vulnerable_range` in the 7.x line; `undici@5.29.0` still matches all 6.x-line alerts (their ranges have no lower bound) and remains open
- [x] `yarn typecheck` passes
- [x] `yarn test` passes (2 tests; does not exercise undici — it is build/tooling-only in this repo)
- [x] `yarn build` passes (Next.js production build)
- [x] `yarn knip` passes (one pre-existing, unrelated config hint: `sort-package-json` in `ignoreBinaries`)
- [x] `yarn biome check .` passes (two pre-existing, unrelated info-level notices about the biome config schema version)
- [ ] `yarn e2e` skipped — Playwright config requires a running app server (`baseURL: http://localhost:3000`, `VERCEL_BYPASS_SECRET` for deployed-preview auth) with no local auto-start; not fabricated, deferred to CI/preview deploy

## References

- https://github.com/brianespinosa/resume/security/dependabot/173
- https://github.com/brianespinosa/resume/security/dependabot/172
- https://github.com/brianespinosa/resume/security/dependabot/171
- https://github.com/brianespinosa/resume/security/dependabot/170
- https://github.com/brianespinosa/resume/security/dependabot/169
- https://github.com/brianespinosa/resume/security/dependabot/168
- https://github.com/brianespinosa/resume/security/dependabot/167
- https://github.com/brianespinosa/resume/security/dependabot/166
- https://github.com/brianespinosa/resume/security/dependabot/145
- https://github.com/brianespinosa/resume/security/dependabot/144
- https://github.com/brianespinosa/resume/security/dependabot/143
- https://github.com/brianespinosa/resume/security/dependabot/142
- https://github.com/brianespinosa/resume/security/dependabot/139
- https://github.com/brianespinosa/resume/security/dependabot/138
- https://github.com/brianespinosa/resume/security/dependabot/137
- https://github.com/brianespinosa/resume/security/dependabot/136
- https://github.com/brianespinosa/resume/security/dependabot/135
- https://github.com/brianespinosa/resume/security/dependabot/115
- https://github.com/brianespinosa/resume/security/dependabot/114
