### PR TITLE
fix(deps): resolve Dependabot alert for brace-expansion

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "@vercel/fun/tar": "^7.5.11",
     "@vercel/node/undici": "^5.29.0",
     "@vercel/python-analysis/minimatch": "^10.2.3",
-    "micromatch/picomatch": "^2.3.2"
+    "micromatch/picomatch": "^2.3.2",
+    "minimatch@npm:10.2.5/brace-expansion": ">=5.0.7 <6"
   },
   "dependencies": {
     "@ariakit/react": "0.4.37",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3696,6 +3696,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"brace-expansion@npm:>=5.0.7 <6":
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
+  dependencies:
+    balanced-match: "npm:^4.0.2"
+  checksum: 10c0/3dea38884a1c3c8b1c9c44a7402a0c76fca460f70cffb3127242b0b4cbf4472019e022ade021eec44838ff19f1dac2625dfd11dd459d7e1e055b0698a8d52fec
+  languageName: node
+  linkType: hard
+
 "brace-expansion@npm:^1.1.7":
   version: 1.1.16
   resolution: "brace-expansion@npm:1.1.16"
@@ -3703,15 +3712,6 @@ __metadata:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
   checksum: 10c0/b2a915bbedbf4e45840d1fb9a4d391bbf26a79475bd134714d3cee34f1f0edb0ce982738028843be5fbaf8039429f71fa487df8c915b6065ced542c83e58fae6
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:^5.0.5":
-  version: 5.0.5
-  resolution: "brace-expansion@npm:5.0.5"
-  dependencies:
-    balanced-match: "npm:^4.0.2"
-  checksum: 10c0/4d238e14ed4f5cc9c07285550a41cef23121ca08ba99fa9eb5b55b580dcb6bf868b8210aa10526bdc9f8dc97f33ca2a7259039c4cc131a93042beddb424c48e3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Resolves 1 Dependabot alert for `brace-expansion` by adding a version-scoped override
- Target version: >=5.0.7 <6
- Resolved version: 5.0.9

## Alerts resolved

| # | CVE | Severity | EPSS | Summary |
|---|---|---|---|---|
| [#147](https://github.com/brianespinosa/resume/security/dependabot/147) | CVE-2026-13149 | high | 27.5% | brace-expansion: DoS via exponential-time expansion of consecutive non-expanding {} groups |

## Merge risk: Medium (4/10)

| Factor | Score | Evidence |
|---|---|---|
| Version delta | 0 | 5.0.5 -> 5.0.9 (patch) |
| Runtime exposure | 1 | transitive under a runtime dependency |
| Usage surface | 0 | no source imports found for parents of brace-expansion (build or tooling only) |
| Test signal | 1 | tests pass; affected modules not clearly exercised |
| Verification | 2 | one or more scripts skipped or partially run |

## Dependency chain

```
├─ minimatch@npm:10.2.5
│  └─ brace-expansion@npm:5.0.5 (via npm:^5.0.5)
│
└─ minimatch@npm:3.1.5
   └─ brace-expansion@npm:1.1.16 (via npm:^1.1.7)
```

`brace-expansion` resolves to two independent major lines via two different `minimatch` versions. Only the copy under `minimatch@10.2.5` (5.0.5) falls inside the alert's `vulnerable_range` (`>= 3.0.0, < 5.0.7`); the copy under `minimatch@3.1.5` (1.1.16) is below that range and was never vulnerable, so it is intentionally left untouched. A plain `minimatch/brace-expansion` resolution would have force-upgraded the unaffected 1.x copy too, so this uses yarn's version-scoped resolution syntax `minimatch@npm:10.2.5/brace-expansion` to target only the vulnerable parent version.

## Changes

```json
"resolutions": {
    "minimatch@npm:10.2.5/brace-expansion": ">=5.0.7 <6"
}
```

## Verification

- [x] Lockfile validated: `brace-expansion@npm:10.2.5`'s copy now resolves to 5.0.9, which satisfies `>=5.0.7 <6`. The adapter's `validate` command flags the untouched `1.1.16` copy as a violation of this constraint, but that copy is outside the alert's `vulnerable_range` (`< 5.0.7` only applies from `>= 3.0.0`), so this is a false positive from validating against the derived constraint rather than the alert range; the fix is complete for alert #147.
- [x] `yarn typecheck` passes
- [x] `yarn test` passes (2 tests)
- [x] `yarn build` passes
- [x] `yarn knip` passes (one pre-existing, unrelated config hint about `sort-package-json`)
- [x] `yarn biome check .` passes (two pre-existing, unrelated info-level notices about `biome.json` schema version)
- [ ] `yarn e2e` skipped: requires a running preview server not available in this environment; defer to CI

## References

- https://github.com/brianespinosa/resume/security/dependabot/147