### PR TITLE
fix(deps): resolve Dependabot alerts for undici 6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "resolutions": {
     "@vercel/backends/srvx": "^0.11.13",
+    "@vercel/blob/undici": ">=6.28.0 <7",
     "@vercel/fun/@tootallnate/once": "^3.0.1",
     "@vercel/fun/tar": "^7.5.11",
     "@vercel/node/undici": "^5.29.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8069,10 +8069,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^6.23.0":
-  version: 6.24.1
-  resolution: "undici@npm:6.24.1"
-  checksum: 10c0/53fdbaa357139a2c12deed34f67d67fc6ad269630ba85a1507e7717f53ad2d3a02c95fbd17d3ab321e34c60b6f0a716cdc2f7e2eca1e07178702dc89cc3a73c4
+"undici@npm:>=6.28.0 <7":
+  version: 6.28.0
+  resolution: "undici@npm:6.28.0"
+  checksum: 10c0/3029a70df06b38b5b2f30732932a1e92544c753cd82c8abdf0d35afad48e0ba91612e79fe3a442dbbb9434d6a9eba2b714d5ea28984c903dda2b5d5444f38354
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Resolves 8 Dependabot alert(s) for `undici` in the 6.x line by adding a scoped override
- Target version: >=6.28.0
- Resolved version: 6.28.0
- Other major lines of this package (5.x, 7.x) are fixed by their own PRs

## Alerts resolved

| # | CVE | Severity | EPSS | Summary |
|---|---|---|---|---|
| [#172](https://github.com/brianespinosa/resume/security/dependabot/172) | CVE-2026-15157 | medium | 5.0% | CRLF Injection via blob-like body 'type' property |
| [#169](https://github.com/brianespinosa/resume/security/dependabot/169) | CVE-2026-16729 | medium | 6.3% | Cookie attribute injection via unsanitized domain and unparsed setCookie fields |
| [#167](https://github.com/brianespinosa/resume/security/dependabot/167) | CVE-2026-16728 | medium | 7.3% | Downstream response desynchronization via retry interceptor |
| [#144](https://github.com/brianespinosa/resume/security/dependabot/144) | CVE-2026-11525 | low | 15.0% | Set-Cookie SameSite attribute downgrade via permissive substring matching |
| [#142](https://github.com/brianespinosa/resume/security/dependabot/142) | CVE-2026-9679 | medium | 17.6% | HTTP header injection via Set-Cookie percent-decoding |
| [#137](https://github.com/brianespinosa/resume/security/dependabot/137) | CVE-2026-6733 | low | 12.6% | HTTP response queue poisoning via keep-alive socket reuse |
| [#115](https://github.com/brianespinosa/resume/security/dependabot/115) | CVE-2026-1527 | medium | 16.7% | CRLF Injection via upgrade option |
| [#114](https://github.com/brianespinosa/resume/security/dependabot/114) | CVE-2026-1525 | medium | 39.5% | HTTP Request/Response Smuggling issue |

## Merge risk: Medium (5/14)

| Factor | Score | Evidence |
|---|---|---|
| Version delta | 1 | 6.24.1 -> 6.28.0 (minor) |
| Runtime exposure | 1 | transitive under a runtime dependency |
| Usage surface | 0 | no source imports found for parents of undici (build or tooling only) |
| Test signal | 1 | tests pass; affected modules not clearly exercised |
| Verification | 2 | one or more scripts skipped or partially run |
| Override blast radius | 0 | scoped override: only the dependency paths that carried the alerts are pinned |
| Declared-range distance | 0 | no major line crossed; dependents declare ^6.23.0 |

## Dependency chain

```
├─ @vercel/blob@npm:2.8.0
│  └─ undici@npm:6.28.0 (via npm:>=6.28.0 <7)
│
├─ @vercel/node@npm:5.10.1
│  └─ undici@npm:5.29.0 (via npm:^5.29.0)
│
├─ @vercel/sandbox@npm:2.4.0
│  └─ undici@npm:7.27.2 (via npm:^7.27.1)
│
├─ vercel@npm:59.1.4
│  └─ undici@npm:5.29.0 (via npm:5.29.0)
│
└─ vercel@npm:59.1.4 [d3ee5]
   └─ undici@npm:5.29.0 (via npm:5.29.0)
```

Only `@vercel/blob` resolves undici on the 6.x line; `@vercel/node`/`vercel` sit on 5.x and
`@vercel/sandbox` on 7.x, each fixed by their own PR.

## Changes

```json
"resolutions": {
  "@vercel/blob/undici": ">=6.28.0 <7"
}
```

## Not fixed by this PR

| Version | Alerts still open | Remediation |
|---|---|---|
| 5.29.0 | GHSA-m8rv-5g2x-5cg5, GHSA-v3r7-h72x-cjcm, GHSA-8xcm-r25x-g524, GHSA-g8m3-5g58-fq7m, GHSA-p88m-4jfj-68fv, GHSA-35p6-xmwp-9g52, GHSA-4992-7rv2-5pvq, GHSA-2mjp-6q6p-2qxm | no patched release in the 5.x line for this range; needs a major bump of `@vercel/node`/`vercel` or dropping them (handled by the 5.x-line fix PR) |

## Verification

- [x] Lockfile validated: 1 resolved version in the 6.x line (6.28.0) satisfies `>=6.28.0 <7`, and no resolved copy still matches any alert's vulnerable range
- [x] `yarn typecheck` passes
- [x] `yarn test` passes (2/2)
- [x] `yarn build` passes
- [x] `yarn knip` passes (1 configuration hint, unrelated to this change)
- [x] `yarn check` passes (pre-existing biome config-version warnings, unrelated to this change)
- [ ] `yarn e2e` skipped: requires a running dev server or deployed preview URL (`PLAYWRIGHT_BASE_URL`) not available in this environment; CI is the verifier

## References

- https://github.com/brianespinosa/resume/security/dependabot/172
- https://github.com/brianespinosa/resume/security/dependabot/169
- https://github.com/brianespinosa/resume/security/dependabot/167
- https://github.com/brianespinosa/resume/security/dependabot/144
- https://github.com/brianespinosa/resume/security/dependabot/142
- https://github.com/brianespinosa/resume/security/dependabot/137
- https://github.com/brianespinosa/resume/security/dependabot/115
- https://github.com/brianespinosa/resume/security/dependabot/114