### PR TITLE
fix(deps): resolve 4 Dependabot alert(s) for postcss 8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "@vercel/fun/tar": "^7.5.11",
     "@vercel/node/undici": "^5.29.0",
     "@vercel/python-analysis/minimatch": "^10.2.3",
-    "micromatch/picomatch": "^2.3.2"
+    "micromatch/picomatch": "^2.3.2",
+    "next/postcss": ">=8.5.23 <9",
+    "vite/postcss": ">=8.5.23 <9"
   },
   "dependencies": {
     "@ariakit/react": "0.4.37",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6167,7 +6167,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11, nanoid@npm:^3.3.16, nanoid@npm:^3.3.17":
+"nanoid@npm:^3.3.17":
   version: 3.3.18
   resolution: "nanoid@npm:3.3.18"
   bin:
@@ -6824,18 +6824,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.5.23":
-  version: 8.5.23
-  resolution: "postcss@npm:8.5.23"
-  dependencies:
-    nanoid: "npm:^3.3.16"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/ed714e635b330bb42666ecdd0c0b4f30224ded15b0b0052d6bc2b92832f2cf17d1c1141359453f96f0a84f8fbf4c405a74df187f559163b8f31131b2535455aa
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.25":
+"postcss@npm:>=8.5.23 <9":
   version: 8.5.26
   resolution: "postcss@npm:8.5.26"
   dependencies:
@@ -6843,17 +6832,6 @@ __metadata:
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
   checksum: 10c0/2bdafc00d96bd57b6649a52e458864a4bf58ee56cfdbe4aea1472b5cccc127e6c1ad653bd0bec50d211e650eb0b9270c80e1e72aff2e2fa40d9e7363234d6e43
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.8":
-  version: 8.5.9
-  resolution: "postcss@npm:8.5.9"
-  dependencies:
-    nanoid: "npm:^3.3.11"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/7cb2b32202ea1ead03f15cfbb2756a64a0f98942378e99b3dfce33678fe5eaf93e31d675a46e3a0dfb417d7b49b82d8999d0dd42a33c3b128e71ade0f978719a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Resolves 4 Dependabot alert(s) for `postcss` in the 8.x line by adding scoped overrides
- Target version: >=8.5.23
- Resolved version: 8.5.26
- Other major lines of this package, if any, are fixed by their own PRs

## Alerts resolved

| # | CVE | Severity | EPSS | Summary |
|---|---|---|---|---|
| [#157](https://github.com/brianespinosa/resume/security/dependabot/157) | CVE-2026-73646 | high | 30.8% | PostCSS: Path Traversal in Previous Source Map Auto-Loading (sourceMappingURL) leads to Arbitrary .map File Disclosure |
| [#156](https://github.com/brianespinosa/resume/security/dependabot/156) | CVE-2026-45623 | high | 46.5% | PostCSS: Arbitrary file read and information disclosure via attacker-controlled sourceMappingURL in CSS comments |
| [#165](https://github.com/brianespinosa/resume/security/dependabot/165) | CVE-2026-69153 | medium | 23.7% | PostCSS: incomplete fix of GHSA-6g55-p6wh-862q — attacker-controlled sourceMappingURL reads arbitrary .map files when `from` is unset |
| [#123](https://github.com/brianespinosa/resume/security/dependabot/123) | CVE-2026-41305 | medium | 10.5% | PostCSS has XSS via Unescaped </style> in its CSS Stringify Output |

## Merge risk: Medium (6/14)

| Factor | Score | Evidence |
|---|---|---|
| Version delta | 0 | 8.5.9 -> 8.5.26 (patch; parents declare 8.5.23) |
| Runtime exposure | 1 | transitive under a runtime dependency |
| Usage surface | 2 | imported in 6 module(s) for parents of postcss |
| Test coverage | 2 | none of the 6 affected module(s) is covered by a test (next.config.ts, src/app/layout.tsx, src/app/not-found.tsx, src/app/page.tsx, src/app/robots.ts, and 1 more uncovered) |
| CI presence | 0 | .github/workflows/ci.yml triggers on pull_request and runs: yarn typecheck |
| Override blast radius | 0 | scoped override: only the dependency paths that carried the alerts are pinned |
| Declared-range distance | 1 | crosses the pinned range 8.5.23; dependents declare 8.5.23, ^8.5.25, ^8.5.8 |

## Dependency chain

```
├─ next@npm:16.3.1
│  └─ postcss@npm:8.5.23 (via npm:8.5.23)
│
├─ next@npm:16.3.1 [d3ee5]
│  └─ postcss@npm:8.5.23 (via npm:8.5.23)
│
├─ vite@npm:8.0.8
│  └─ postcss@npm:8.5.9 (via npm:^8.5.8)
│
├─ vite@npm:8.2.1
│  └─ postcss@npm:8.5.26 (via npm:^8.5.25)
│
└─ vite@npm:8.2.1 [d3ee5]
   └─ postcss@npm:8.5.26 (via npm:^8.5.25)
```

## Changes

```json
{
  "resolutions": {
    "next/postcss": ">=8.5.23 <9",
    "vite/postcss": ">=8.5.23 <9"
  }
}
```

## Verification

- [x] Lockfile validated: 1 resolved version(s) in the 8.x line satisfy
      `>=8.5.23 <9`, and no resolved copy still matches any alert's vulnerable range
- [x] No collateral: every copy of `postcss` on the other major lines resolves exactly as it did
      before this change (`other_line_moves: []`, against the pre-fix baseline)
- CI on this PR is the verifier; coverage and CI presence are scored above

## References

- https://github.com/brianespinosa/resume/security/dependabot/165
- https://github.com/brianespinosa/resume/security/dependabot/157
- https://github.com/brianespinosa/resume/security/dependabot/156
- https://github.com/brianespinosa/resume/security/dependabot/123