### PR TITLE
fix(deps): resolve 3 Dependabot alerts for js-yaml 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@vercel/fun/@tootallnate/once": "^3.0.1",
     "@vercel/fun/tar": "^7.5.11",
     "@vercel/node/undici": "^5.29.0",
+    "@vercel/python-analysis/js-yaml": ">=4.3.1 <5",
     "@vercel/python-analysis/minimatch": "^10.2.3",
     "micromatch/picomatch": "^2.3.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5066,14 +5066,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:4.1.1":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
+"js-yaml@npm:>=4.3.1 <5":
+  version: 4.3.1
+  resolution: "js-yaml@npm:4.3.1"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
+  checksum: 10c0/13c500ca322e0c3f8c81686e6ecda96d2ea37b45247a420c17c7db36932d6965cc27391abc2d1a104501600e7f0d947a5f8b7be6db619c4fefa87901b3512807
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Resolves 3 Dependabot alert(s) for `js-yaml` in the 4.x line by adding a scoped override
- Target version: >=4.3.1
- Resolved version: 4.3.1
- Other major lines of this package, if any, are fixed by their own PRs

## Alerts resolved

| # | CVE | Severity | EPSS | Summary |
|---|---|---|---|---|
| [#174](https://github.com/brianespinosa/resume/security/dependabot/174) | GHSA-5p4m-2wfm-xmqj | high | 0% | JS-YAML: Quadratic CPU consumption in !!omap resolution (3.x and 4.x) — CVE-2026-59870 fix not backported |
| [#148](https://github.com/brianespinosa/resume/security/dependabot/148) | CVE-2026-59869 | high | 43.5% | js-yaml: YAML merge-key chains can force quadratic CPU consumption |
| [#146](https://github.com/brianespinosa/resume/security/dependabot/146) | CVE-2026-53550 | medium | 30.5% | JS-YAML: Quadratic-complexity DoS in merge key handling via repeated aliases |

## Merge risk: Low (3/14)

| Factor | Score | Evidence |
|---|---|---|
| Version delta | 1 | 4.1.1 -> 4.3.1 (minor; parents declare 4.1.1) |
| Runtime exposure | 1 | transitive under a runtime dependency |
| Usage surface | 0 | no source imports found for parents of js-yaml (build or tooling only) |
| Test coverage | 0 | no source imports; a build script exists, so a broken tooling pin fails at build |
| CI presence | 0 | .github/workflows/ci.yml triggers on pull_request and runs: yarn typecheck |
| Override blast radius | 0 | scoped override: only the dependency paths that carried the alerts are pinned |
| Declared-range distance | 1 | crosses the pinned range 4.1.1; dependents declare 4.1.1 |

## Dependency chain

```
└─ @vercel/python-analysis@npm:0.13.2
   └─ js-yaml@npm:4.1.1 (via npm:4.1.1)
```

## Changes

```json
"resolutions": {
  "@vercel/python-analysis/js-yaml": ">=4.3.1 <5"
}
```

## Verification

- [x] Lockfile validated: 1 resolved version(s) in the 4.x line satisfy
      `>=4.3.1 <5`, and no resolved copy still matches any alert's vulnerable range
- CI on this PR is the verifier; coverage and CI presence are scored above

## References

- https://github.com/brianespinosa/resume/security/dependabot/174
- https://github.com/brianespinosa/resume/security/dependabot/148
- https://github.com/brianespinosa/resume/security/dependabot/146