### PR TITLE
fix(deps): resolve 11 Dependabot alerts for undici 7.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "vite/postcss": ">=8.5.23 <9",
     "@vitejs/plugin-react/vite": ">=8.0.16 <9",
     "@vitest/mocker/vite": ">=8.0.16 <9",
-    "vitest/vite": ">=8.0.16 <9"
+    "vitest/vite": ">=8.0.16 <9",
+    "@vercel/sandbox/undici": ">=7.29.0 <8"
   },
   "dependencies": {
     "@ariakit/react": "0.4.37",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7867,17 +7867,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici@npm:>=7.29.0 <8":
+  version: 7.29.0
+  resolution: "undici@npm:7.29.0"
+  checksum: 10c0/85ea96e91e7f3de24de678cbbc54230fdd641a3b0643005f2aef044af1f1a2db8fbecb88b28e6fa78bb41ffeafda4479b57075b6b6ab92beac4b7b5ab53f9b10
+  languageName: node
+  linkType: hard
+
 "undici@npm:^6.23.0":
   version: 6.24.1
   resolution: "undici@npm:6.24.1"
   checksum: 10c0/53fdbaa357139a2c12deed34f67d67fc6ad269630ba85a1507e7717f53ad2d3a02c95fbd17d3ab321e34c60b6f0a716cdc2f7e2eca1e07178702dc89cc3a73c4
-  languageName: node
-  linkType: hard
-
-"undici@npm:^7.27.1":
-  version: 7.27.2
-  resolution: "undici@npm:7.27.2"
-  checksum: 10c0/714632147c80eb8eda8a52df51b481d346df5e035ccc1d87eb3bbcb8f92ec25d7cbbe81abdeae5db4e37a93e490c8d2fa2359ecdca4b2c5c6c513dcd2626ad47
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Resolves 11 Dependabot alert(s) for `undici` in the 7.x line by adding a scoped override
- Target version: >=7.29.0
- Resolved version: 7.29.0
- Other major lines of this package, if any, are fixed by their own PRs

## Alerts resolved

| # | CVE | Severity | EPSS | Summary |
|---|---|---|---|---|
| [#173](https://github.com/brianespinosa/resume/security/dependabot/173) | CVE-2026-15157 | medium | 5.0% | undici vulnerable to CRLF Injection via blob-like body 'type' property |
| [#171](https://github.com/brianespinosa/resume/security/dependabot/171) | CVE-2026-14643 | medium | 13.9% | undici vulnerable to cross-user information disclosure via whitespace around equals in Cache-Control directives |
| [#170](https://github.com/brianespinosa/resume/security/dependabot/170) | CVE-2026-16729 | medium | 6.3% | undici vulnerable to cookie attribute injection via unsanitized domain and unparsed setCookie fields |
| [#168](https://github.com/brianespinosa/resume/security/dependabot/168) | CVE-2026-16728 | medium | 7.3% | undici vulnerable to downstream response desynchronization via retry interceptor |
| [#166](https://github.com/brianespinosa/resume/security/dependabot/166) | CVE-2026-13697 | high | 25.5% | undici vulnerable to cross-user information disclosure and parse-time crash via degenerate private cache directives |
| [#145](https://github.com/brianespinosa/resume/security/dependabot/145) | CVE-2026-11525 | low | 15.0% | undici vulnerable to Set-Cookie SameSite attribute downgrade via permissive substring matching |
| [#143](https://github.com/brianespinosa/resume/security/dependabot/143) | CVE-2026-9679 | medium | 17.6% | undici vulnerable to HTTP header injection via Set-Cookie percent-decoding |
| [#139](https://github.com/brianespinosa/resume/security/dependabot/139) | CVE-2026-6734 | high | 27.6% | undici vulnerable to cross-origin request routing via SOCKS5 proxy pool reuse |
| [#138](https://github.com/brianespinosa/resume/security/dependabot/138) | CVE-2026-6733 | low | 12.6% | undici vulnerable to HTTP response queue poisoning via keep-alive socket reuse |
| [#136](https://github.com/brianespinosa/resume/security/dependabot/136) | CVE-2026-9697 | high | 37.5% | undici vulnerable to TLS certificate validation bypass via dropped requestTls in SOCKS5 ProxyAgent |
| [#135](https://github.com/brianespinosa/resume/security/dependabot/135) | CVE-2026-9678 | medium | 28.5% | undici vulnerable to cross-user information disclosure via shared cache whitespace bypass |

## Merge risk: Low (2/14)

| Factor | Score | Evidence |
|---|---|---|
| Version delta | 1 | 7.27.2 -> 7.29.0 (minor) |
| Runtime exposure | 1 | transitive under a runtime dependency |
| Usage surface | 0 | no source imports found for parents of undici (build or tooling only) |
| Test coverage | 0 | no source imports; a build script exists, so a broken tooling pin fails at build |
| CI presence | 0 | .github/workflows/ci.yml triggers on pull_request and runs: yarn typecheck |
| Override blast radius | 0 | scoped override: only the dependency paths that carried the alerts are pinned |
| Declared-range distance | 0 | no major line crossed; dependents declare ^7.27.1 |

## Dependency chain

```
├─ @vercel/blob@npm:2.8.0
│  └─ undici@npm:6.24.1 (via npm:^6.23.0)
│
├─ @vercel/node@npm:5.10.1
│  └─ undici@npm:5.29.0 (via npm:^5.29.0)
│
├─ @vercel/sandbox@npm:2.4.0
│  └─ undici@npm:7.27.2 (via npm:^7.27.1)
│
├─ vercel@npm:59.1.4
│  └─ undici@npm:5.29.0 (via npm:5.29.0)
│
└─ vercel@npm:59.1.4 [d3ee5]
   └─ undici@npm:5.29.0 (via npm:5.29.0)
```

Only `@vercel/sandbox` resolves `undici` on the 7.x line. `@vercel/node`, `@vercel/blob` and the root `vercel` devDependency resolve it on the 5.x/6.x lines via their own pre-existing constraints and are out of scope for this PR.

## Changes

```json
{
  "resolutions": {
    "@vercel/sandbox/undici": ">=7.29.0 <8"
  }
}
```

A pre-existing scoped override, `"@vercel/node/undici": "^5.29.0"`, pins that parent's copy on the 5.x line and is unchanged by this PR.

## Verification

- [x] Lockfile validated: 1 resolved version in the 7.x line satisfies `>=7.29.0 <8`, and no resolved copy still matches any alert's vulnerable range
- [x] No collateral: every copy of `undici` on the other major lines resolves exactly as it did before this change (`other_line_moves: []`, against the pre-fix baseline; confirmed additionally via `yarn why undici -R` showing `@vercel/node` still resolving `5.29.0` via its existing `^5.29.0` override)
- CI on this PR is the verifier; coverage and CI presence are scored above

## References

- https://github.com/brianespinosa/resume/security/dependabot/173
- https://github.com/brianespinosa/resume/security/dependabot/171
- https://github.com/brianespinosa/resume/security/dependabot/170
- https://github.com/brianespinosa/resume/security/dependabot/168
- https://github.com/brianespinosa/resume/security/dependabot/166
- https://github.com/brianespinosa/resume/security/dependabot/145
- https://github.com/brianespinosa/resume/security/dependabot/143
- https://github.com/brianespinosa/resume/security/dependabot/139
- https://github.com/brianespinosa/resume/security/dependabot/138
- https://github.com/brianespinosa/resume/security/dependabot/136
- https://github.com/brianespinosa/resume/security/dependabot/135