### PR TITLE
chore(deps): remove 10 stale dependency pins

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,21 +29,11 @@
     ]
   },
   "resolutions": {
-    "@vercel/backends/srvx": "^0.11.13",
-    "@vercel/blob/undici": ">=6.28.0 <7",
     "@vercel/fun/@tootallnate/once": "^3.0.1",
     "@vercel/fun/tar": "^7.5.11",
     "@vercel/node/undici": "^5.29.0",
     "@vercel/python-analysis/js-yaml": ">=4.3.1 <5",
-    "@vercel/python-analysis/minimatch": "^10.2.3",
-    "@vercel/sandbox/undici": ">=7.29.0 <8",
-    "@vitejs/plugin-react/vite": ">=8.0.16 <9",
-    "@vitest/mocker/vite": ">=8.0.16 <9",
-    "micromatch/picomatch": "^2.3.2",
-    "minimatch@10.2.5/brace-expansion": ">=5.0.7 <6",
-    "next/postcss": ">=8.5.23 <9",
-    "vite/postcss": ">=8.5.23 <9",
-    "vitest/vite": ">=8.0.16 <9"
+    "@vercel/python-analysis/minimatch": "^10.2.3"
   },
   "dependencies": {
     "@ariakit/react": "0.4.37",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3639,15 +3639,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:>=5.0.7 <6":
-  version: 5.0.9
-  resolution: "brace-expansion@npm:5.0.9"
-  dependencies:
-    balanced-match: "npm:^4.0.2"
-  checksum: 10c0/3dea38884a1c3c8b1c9c44a7402a0c76fca460f70cffb3127242b0b4cbf4472019e022ade021eec44838ff19f1dac2625dfd11dd459d7e1e055b0698a8d52fec
-  languageName: node
-  linkType: hard
-
 "brace-expansion@npm:^1.1.7":
   version: 1.1.18
   resolution: "brace-expansion@npm:1.1.18"
@@ -3655,6 +3646,15 @@ __metadata:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
   checksum: 10c0/3432c18a9e2ebf94162d4effb62198bd0adea06a9f332b2c0188df5d5e30b1e51ea3c848b6608e47d0b857ebe1ea5b3888ed3326dd3c4f6f9645c94153cf9c14
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^5.0.5":
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
+  dependencies:
+    balanced-match: "npm:^4.0.2"
+  checksum: 10c0/3dea38884a1c3c8b1c9c44a7402a0c76fca460f70cffb3127242b0b4cbf4472019e022ade021eec44838ff19f1dac2625dfd11dd459d7e1e055b0698a8d52fec
   languageName: node
   linkType: hard
 
@@ -6008,7 +6008,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.17":
+"nanoid@npm:^3.3.16, nanoid@npm:^3.3.17":
   version: 3.3.18
   resolution: "nanoid@npm:3.3.18"
   bin:
@@ -6604,7 +6604,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.3.2":
+"picomatch@npm:^2.3.1":
   version: 2.3.2
   resolution: "picomatch@npm:2.3.2"
   checksum: 10c0/a554d1709e59be97d1acb9eaedbbc700a5c03dbd4579807baed95100b00420bc729335440ef15004ae2378984e2487a7c1cebd743cfdb72b6fa9ab69223c0d61
@@ -6665,7 +6665,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:>=8.5.23 <9":
+"postcss@npm:8.5.23":
+  version: 8.5.23
+  resolution: "postcss@npm:8.5.23"
+  dependencies:
+    nanoid: "npm:^3.3.16"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/ed714e635b330bb42666ecdd0c0b4f30224ded15b0b0052d6bc2b92832f2cf17d1c1141359453f96f0a84f8fbf4c405a74df187f559163b8f31131b2535455aa
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.5.25, postcss@npm:^8.5.26":
   version: 8.5.26
   resolution: "postcss@npm:8.5.26"
   dependencies:
@@ -7424,12 +7435,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"srvx@npm:^0.11.13":
-  version: 0.11.15
-  resolution: "srvx@npm:0.11.15"
+"srvx@npm:0.11.16":
+  version: 0.11.16
+  resolution: "srvx@npm:0.11.16"
   bin:
     srvx: bin/srvx.mjs
-  checksum: 10c0/3f72be7bfb321ad21ae7698a721f1a16b855313d1fa8498a0d68adbec65f8f2d2c5a83cf37849f6489c7403870535a70958976636df3d5274cd785b61b7aa635
+  checksum: 10c0/cd3ed12c12481e2852409a7dfaa8c1ae0a7264769e9239e4a34da48033029c2ce4b2bccfd648a49f9bb10d13c4be91fcdbdb50feb08bf3de19bc8cfe71efa0a2
   languageName: node
   linkType: hard
 
@@ -7867,14 +7878,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:>=6.28.0 <7":
+"undici@npm:^6.23.0":
   version: 6.28.0
   resolution: "undici@npm:6.28.0"
   checksum: 10c0/3029a70df06b38b5b2f30732932a1e92544c753cd82c8abdf0d35afad48e0ba91612e79fe3a442dbbb9434d6a9eba2b714d5ea28984c903dda2b5d5444f38354
   languageName: node
   linkType: hard
 
-"undici@npm:>=7.29.0 <8":
+"undici@npm:^7.27.1":
   version: 7.29.0
   resolution: "undici@npm:7.29.0"
   checksum: 10c0/85ea96e91e7f3de24de678cbbc54230fdd641a3b0643005f2aef044af1f1a2db8fbecb88b28e6fa78bb41ffeafda4479b57075b6b6ab92beac4b7b5ab53f9b10
@@ -8161,7 +8172,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:>=8.0.16 <9":
+"vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0":
   version: 8.2.2
   resolution: "vite@npm:8.2.2"
   dependencies:


### PR DESCRIPTION
## Summary

Removes 10 dependency pins this audit found no longer needed. Each was tested on its own (pin out,
install, every newly resolved version judged against every published advisory for its package),
and then the whole set was tested together in one install.

5 pins on `undici`, `tar`, `js-yaml`, and `minimatch` (via `@vercel/fun`, `@vercel/node`, and
`@vercel/python-analysis`) were left in place: removing them naturally resolves a version that is
still vulnerable, in one case (`@vercel/node/undici`) an even lower and more vulnerable version
than the version the pin currently holds.

## Pins removed

| Pin | Scope | Value | Was holding | Now resolves | Advisories checked |
|---|---|---|---|---|---|
| `@vercel/backends/srvx` | scoped | `^0.11.13` | `srvx` 0.11.15 | 0.11.16 | 1, none admits 0.11.16 |
| `@vercel/blob/undici` | scoped | `>=6.28.0 <7` | `undici` 6.28.0 | 6.28.0 (unchanged; `@vercel/blob`'s own `^6.23.0` already resolves here) | n/a, empty delta |
| `@vercel/sandbox/undici` | scoped | `>=7.29.0 <8` | `undici` 7.29.0 | 7.29.0 (unchanged; `@vercel/sandbox`'s own `^7.27.1` already resolves here) | n/a, empty delta |
| `@vitejs/plugin-react/vite` | scoped | `>=8.0.16 <9` | `vite` 8.2.1/8.2.2 | unchanged; sibling pins on `vite` held the line | n/a, empty delta |
| `@vitest/mocker/vite` | scoped | `>=8.0.16 <9` | `vite` 8.2.1/8.2.2 | unchanged; sibling pins on `vite` held the line | n/a, empty delta |
| `vitest/vite` | scoped | `>=8.0.16 <9` | `vite` 8.2.1/8.2.2 | unchanged; sibling pins on `vite` held the line | n/a, empty delta |
| `micromatch/picomatch` | scoped | `^2.3.2` | `picomatch` 2.3.2/4.0.4/4.0.5 | unchanged; `micromatch`'s own `^2.3.1` already resolves 2.3.2 | n/a, empty delta |
| `minimatch@10.2.5/brace-expansion` | scoped | `>=5.0.7 <6` | `brace-expansion` 5.0.9 | unchanged; `minimatch@10.2.5`'s own `^5.0.5` already resolves 5.0.9 | n/a, empty delta |
| `next/postcss` | scoped | `>=8.5.23 <9` | `postcss` 8.5.26 | newly admits 8.5.23 for `next`'s copy | 5, none admits 8.5.23 |
| `vite/postcss` | scoped | `>=8.5.23 <9` | `postcss` 8.5.26 | unchanged; sibling pin on `postcss` held the line for `vite`'s copy | n/a, empty delta |

Six of these ten are individually-tested rather than independently-safe on their own: each of
`@vitejs/plugin-react/vite`, `@vitest/mocker/vite`, `vitest/vite`, `next/postcss`, and
`vite/postcss` was tested with its sibling pin(s) on the same package still in place. That is what
made removing it individually a no-op; it is not evidence that removing all siblings together is
safe on its own. This PR settles that by testing the whole set together (below), which is the only
place any of them is actually confirmed removed as a set.

## Tested together

All 10 pins removed in one install. Two packages moved:

- `srvx`: 0.11.15 -> 0.11.16 (safe, no advisory admits it)
- `postcss`: gained 8.5.23 alongside the existing 8.5.26 (safe, no advisory admits 8.5.23)

No other package's resolved version set changed.

## Pins left behind

| Pin | Why |
|---|---|
| `@vercel/fun/@tootallnate/once` | naturally resolves 2.0.0, which GHSA-vpq2-c234-7xj6 admits (`< 2.0.1`) |
| `@vercel/fun/tar` | naturally resolves 7.5.7, which multiple advisories admit (e.g. GHSA-83g3-92jg-28cx, `< 7.5.8`) |
| `@vercel/node/undici` | naturally resolves 5.28.4 (an even lower version than the 5.29.0 the pin currently holds), and both 5.28.4 and 5.29.0 are vulnerable per GHSA-c76h-2ccp-4975 and related advisories. This pin is a deliberate, pre-existing hold on `@vercel/node`'s copy of `undici`; it is not "still vulnerable anyway" grounds for removal, it is confirmation the pin is still doing its job |
| `@vercel/python-analysis/js-yaml` | naturally resolves 4.1.1, which GHSA-5p4m-2wfm-xmqj admits (`>= 4.0.0, < 4.3.1`) |
| `@vercel/python-analysis/minimatch` | naturally resolves 10.1.1, which GHSA-7r86-cg39-jmmj and GHSA-23c5-xmqv-rm74 admit (`>= 10.0.0, < 10.2.3`) |

## Collateral changes

Nothing else moved beyond `srvx` and `postcss`, named above.

## Merge risk

### `srvx`

## Merge risk: Low (1/14)

| Factor | Score | Evidence |
|---|---|---|
| Version delta | 0 | 0.11.15 -> 0.11.16 (patch) |
| Runtime exposure | 1 | transitive under a runtime dependency |
| Usage surface | 0 | no source imports found for parents of srvx (build or tooling only) |
| Test coverage | 0 | no source imports; a build script exists, so a broken tooling pin fails at build |
| CI presence | 0 | .github/workflows/ci.yml triggers on pull_request and runs: yarn typecheck |
| Override blast radius | 0 | no override applied by this change |
| Declared-range distance | 0 | no major line crossed; dependents declare 0.11.16 |

### `postcss`

## Merge risk: Medium (5/14)

| Factor | Score | Evidence |
|---|---|---|
| Version delta | 0 | 8.5.26 -> 8.5.23 (patch; parents declare ^8.5.25, ^8.5.26) |
| Runtime exposure | 1 | transitive under a runtime dependency |
| Usage surface | 2 | imported in 6 module(s) for parents of postcss |
| Test coverage | 2 | none of the 6 affected module(s) is covered by a test (next.config.ts, src/app/layout.tsx, src/app/not-found.tsx, src/app/page.tsx, src/app/robots.ts, and 1 more uncovered) |
| CI presence | 0 | .github/workflows/ci.yml triggers on pull_request and runs: yarn typecheck |
| Override blast radius | 0 | no override applied by this change |
| Declared-range distance | 0 | no major line crossed; dependents declare 8.5.23, ^8.5.25, ^8.5.26 |

**Not scored: no longer resolved / no version moved** — `@vercel/blob/undici`, `@vercel/sandbox/undici`,
`@vitejs/plugin-react/vite`, `@vitest/mocker/vite`, `vitest/vite`, `micromatch/picomatch`, and
`minimatch@10.2.5/brace-expansion` all had an empty delta: the package's own declared range (or a
sibling pin) already resolves to the same version the removed pin held, so nothing moved for the
scorer to rate.

## Verification

- [x] Combined install: 10 pins removed together, 2 packages moved, every newly admitted version
      checked against every published advisory for its own package
- CI on this PR is the verifier; coverage and CI presence are scored above

## References

- `@vercel/backends/srvx`, `@vercel/fun/@tootallnate/once`, `@vercel/fun/tar`,
  `@vercel/node/undici`, `@vercel/python-analysis/minimatch`: introduced in
  https://github.com/brianespinosa/resume/pull/128
- `micromatch/picomatch`: introduced in https://github.com/brianespinosa/resume/pull/124
- `next/postcss`, `vite/postcss`: introduced in https://github.com/brianespinosa/resume/pull/370
- `@vitejs/plugin-react/vite`, `@vitest/mocker/vite`, `vitest/vite`: introduced in
  https://github.com/brianespinosa/resume/pull/371
- `@vercel/blob/undici`: no clear introducing commit/PR found for this exact key
- `@vercel/python-analysis/js-yaml`: no clear introducing commit/PR found for this exact key
